### PR TITLE
fix: use correct env var for Telegram bot token

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -6,7 +6,10 @@ import contextlib
 import telebot
 from keybox_checker import analyze_key_node, print_human, human_timedelta
 
-API_TOKEN = os.environ.get("7004525417:AAE-MiUqrgbxhUPdX-mGdWXmNUCqSuvI43Y")
+# Ambil token bot dari environment variable yang benar. Sebelumnya, kode
+# secara keliru menggunakan string token itu sendiri sebagai nama environment
+# variable sehingga selalu gagal menemukan token pada runtime.
+API_TOKEN = os.environ.get("KEYBOX_BOT_TOKEN")
 if not API_TOKEN:
     raise RuntimeError("Environment variable KEYBOX_BOT_TOKEN is not set")
 


### PR DESCRIPTION
## Summary
- Fix telegram_bot API token retrieval to use KEYBOX_BOT_TOKEN env var instead of literal token

## Testing
- `python -m py_compile telegram_bot.py keybox_checker.py`
- `KEYBOX_BOT_TOKEN=dummy:token timeout 5s python telegram_bot.py` (fails: invalid token)


------
https://chatgpt.com/codex/tasks/task_b_68b956062898833390409bbec3e08a44